### PR TITLE
fix: 当SubComponents组件有后缀时,阻止穿透(_catch)事件类型被返回的错误

### DIFF
--- a/src/api/SubComponent/SubReturnType/test/normal.test.ts
+++ b/src/api/SubComponent/SubReturnType/test/normal.test.ts
@@ -37,3 +37,47 @@ type SubDocExpect = {
 };
 
 Checking<typeof SubDoc, SubDocExpect, Test.Pass>();
+// 去除已经声明的穿透事件
+const removeCatchedEvents = SubComponent<{}, CompDoc>()({
+  data: {
+    aaa_str: "string",
+  },
+  events: {
+    aaa_bubblesCaptrueComposed_catch(e) {
+      console.log(e);
+    },
+    aaa_bubblesComposed_catch(e) {
+      console.log(e);
+    },
+    aaa_captrueComposed_catch(e) {
+      console.log(e);
+    },
+  },
+});
+void removeCatchedEvents;
+// 返回穿透的自定义事件,并去除了前缀
+type RemoveSubDoc = never;
+
+Checking<typeof removeCatchedEvents, RemoveSubDoc, Test.Pass>();
+// 去除有后缀时,已经声明的穿透事件
+const removeCatchedEventsOfSuffix = SubComponent<{}, CompDoc, "aa">()({
+  data: {
+    aaaAa_str: "string",
+  },
+  events: {
+    aaaAa_bubblesCaptrueComposed_catch(e) {
+      console.log(e);
+    },
+    aaaAa_bubblesComposed_catch(e) {
+      console.log(e);
+    },
+    aaaAa_captrueComposed_catch(e) {
+      console.log(e);
+    },
+  },
+});
+void removeCatchedEventsOfSuffix;
+// 返回穿透的自定义事件,并去除了前缀
+type RemoveCatchedEventsOfSuffix = never;
+
+Checking<typeof removeCatchedEventsOfSuffix, RemoveCatchedEventsOfSuffix, Test.Pass>();

--- a/src/api/SubComponent/index.ts
+++ b/src/api/SubComponent/index.ts
@@ -231,7 +231,7 @@ type SubComponentConstructor<
     SubEventsDoc,
     SubMethodsDoc
   >,
-) => CreateSubComponentDoc<NonNullable<TOriginalCompDoc["customEvents"]>, SubEventsDoc, MissingRequiredField>;
+) => CreateSubComponentDoc<NonNullable<CurrentCompDoc["customEvents"]>, SubEventsDoc, MissingRequiredField>;
 
 /**
  * 子组件构建函数

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,16 @@ import type { CreateComponentType } from "./types/CreateComponentType";
 import type { DetailedType } from "./types/DetailedType";
 import type { ExtendComponentType } from "./types/ExtendComponentType";
 import type { ParamsEqual } from "./types/TwoParamsEqual";
+export type {
+  Bubbles,
+  BubblesCapture,
+  BubblesCaptureComposed,
+  BubblesComposed,
+  Capture,
+  CaptureComposed,
+  Composed,
+  CustomEventsTags,
+} from "./api/RootComponent/CustomEvents/CustomEventsTag";
 export type { Vant, Wm } from "./thirdLib";
 
 export type {


### PR DESCRIPTION
导出事件相关类型