### PR TITLE
fix: 为subComponents内部组件类型增加 prefix_isReady?:boolean 字段。

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "tsc": "tsc --watch",
     "test": "jest --watch",
     "build": "tsc -p tsconfig.build.json",
-    "check": "eslint . --fix --max-warnings 0 && (dprint check || (dprint fmt && exit 1)) "
+    "check": "tsc --noEmit &&  eslint . --fix --max-warnings 0 && (dprint check || (dprint fmt && exit 1)) "
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^17.6.5",

--- a/src/api/DefineComponent/normalizeOptions/computedWatchHandle/index.ts
+++ b/src/api/DefineComponent/normalizeOptions/computedWatchHandle/index.ts
@@ -5,9 +5,9 @@ import { getPathsValue } from "./getPathsValue";
 import { getPropertiesValue } from "./getPropertiesValue";
 import { initComputedAndGetCache } from "./initComputedAndGetCache";
 
-import { assertNonNullable } from "../../../../utils/assertNonNullable";
 import { deepClone } from "../../../../utils/deepClone";
 import { isEmptyObject } from "../../../../utils/isEmptyObject";
+import { nonNullable } from "../../../../utils/nonNullable";
 import type { Instance } from "../../../RootComponent/Instance/RootComponentInstance";
 import type { FinalOptionsOfComponent } from "..";
 
@@ -68,7 +68,7 @@ export function computedWatchHandle(options: FinalOptionsOfComponent) {
       observersConfig[key] = function(this: Instance, ...newValue: unknown[]) {
         originObserversHandle?.call(this, ...newValue);
 
-        const watchOldValue = assertNonNullable(this.data.__watchOldValue__);
+        const watchOldValue = nonNullable(this.data.__watchOldValue__);
         const oldValue = watchOldValue[key];
 
         if (deepEqual(newValue, oldValue)) return;

--- a/src/api/RootComponent/Events/test/normal.test.ts
+++ b/src/api/RootComponent/Events/test/normal.test.ts
@@ -10,7 +10,7 @@ import type {
   WMBaseEvent,
   WMCustomEvent,
 } from "../../../../types/OfficialTypeAlias";
-import { assertNonNullable } from "../../../../utils/assertNonNullable";
+import { nonNullable } from "../../../../utils/nonNullable";
 import type { ComponentType } from "../../../DefineComponent/ReturnType/ComponentType";
 import { RootComponent } from "../..";
 import type { Bubbles, Capture } from "../../CustomEvents/CustomEventsTag";
@@ -42,7 +42,7 @@ RootComponent()({
     ) {
       Checking<typeof e.detail, string, Test.Pass>;
 
-      const markData = assertNonNullable(e.mark).markData;
+      const markData = nonNullable(e.mark).markData;
 
       Checking<typeof markData, { id: string }, Test.Pass>;
 

--- a/src/api/SubComponent/SubComputed/test/normal.test.ts
+++ b/src/api/SubComponent/SubComputed/test/normal.test.ts
@@ -160,3 +160,11 @@ SubComponent<Root, $aaa>()({
     },
   },
 });
+// computed中可写 额外字段 isReady
+SubComponent<{ data: { _num: number } }, $aaa>()({
+  computed: {
+    aaa_isReady() {
+      return true;
+    },
+  },
+});

--- a/src/api/SubComponent/SubData/test/normal.test.ts
+++ b/src/api/SubComponent/SubData/test/normal.test.ts
@@ -48,7 +48,7 @@ SubComponent<{}, CompDoc>()({
   },
   methods: {
     aaa_1() {
-      // 4 this.data中的data配置数据
+      // 4 this.data中的data配置数据类型应该与文档类型一致,比如aaa_str的类型为"a" | "b"而非string
       void Checking<
         typeof this.data,
         ComputeIntersection<
@@ -78,5 +78,11 @@ SubComponent<{ data: { _num: number } }, CompDoc>()({
         aaa_obj: {} as Mock_User, // aaa_obj 类型为 Mock_User | null 而非 null
       });
     },
+  },
+});
+// data中可写 额外字段 isReady
+SubComponent<{ data: { _num: number } }, CompDoc>()({
+  data: {
+    aaa_isReady: false,
   },
 });

--- a/src/api/SubComponent/SubStore/test/normal.test.ts
+++ b/src/api/SubComponent/SubStore/test/normal.test.ts
@@ -28,3 +28,9 @@ SubComponent<{}, DocA, "a">()({
     _aaaA_xxx: () => user.age,
   },
 });
+// store中可写 额外字段 isReady
+SubComponent<{ data: { _num: number } }, DocA, "a">()({
+  store: {
+    aaaA_isReady: () => false,
+  },
+});

--- a/src/api/SubComponent/index.ts
+++ b/src/api/SubComponent/index.ts
@@ -3,6 +3,7 @@ import type { EmptyObject } from "hry-types/src/Misc/EmptyObject";
 import type { Func } from "hry-types/src/Misc/Func";
 import type { RequiredKeys } from "hry-types/src/Object/RequiredKeys";
 import type { ComputeObject } from "../../types/ComputeObj";
+import type { Extra } from "../../types/Extra";
 import type { GetComponentPrefix } from "../../types/GetComponentPrefix";
 import type { InnerFields } from "../../types/InnerData";
 import type { WMCompOtherOption } from "../../types/OfficialTypeAlias";
@@ -125,8 +126,8 @@ type SubComponentConstructor<
   CurrentCompDoc extends ComponentType = IfExtends<
     TSupplementalPrefix,
     "",
-    TOriginalCompDoc,
-    ReplacePrefix<TOriginalCompDoc, CurrentPrefix>
+    TOriginalCompDoc & { properties: Extra<CurrentPrefix> }, // 为文档增加格外字段
+    ReplacePrefix<TOriginalCompDoc & { properties: Extra<CurrentPrefix> }, CurrentPrefix> // 为文档增加格外字段
   >,
   AllRootDataDoc extends object =
     // rootDoc中的properties是带有可选的,这是为了给使用者(上层组件)提示,而在自身组件实例中并不存在可选状态,故加了Required,正因加了Required使得最终结果不可能为unknown而是`{}`,满足object约束

--- a/src/types/Extra.ts
+++ b/src/types/Extra.ts
@@ -1,1 +1,1 @@
-// export type Extra<Prefix extends string> = Record<`${Prefix}_isReady`, boolean>;
+export type Extra<Prefix extends string> = { [K in `${Prefix}_isReady`]?: boolean };

--- a/src/utils/_utils.ts
+++ b/src/utils/_utils.ts
@@ -1,8 +1,8 @@
-import { assertNonNullable } from "./assertNonNullable";
 import { debounce } from "./debounce";
 import { deepClone } from "./deepClone";
 import { deepEqual } from "./deepEqual";
 import { isEmptyObject } from "./isEmptyObject";
+import { nonNullable } from "./nonNullable";
 import { throttle } from "./throttle";
 
-export { assertNonNullable, debounce, deepClone, deepEqual, isEmptyObject, throttle };
+export { debounce, deepClone, deepEqual, isEmptyObject, nonNullable, throttle };

--- a/src/utils/nonNullable.ts
+++ b/src/utils/nonNullable.ts
@@ -5,7 +5,7 @@ import type { IfContains } from "hry-types/src/Any/IfContains";
  * @param value 类型中必须包含 null 或 undefined
  * @returns 去除 null 和 undefined 后的类型
  */
-export function assertNonNullable<T>(
+export function nonNullable<T>(
   value: IfContains<T, null | undefined, T, "参数类型必须包含 null 或 undefined">,
 ): NonNullable<T> {
   /* istanbul ignore next  */


### PR DESCRIPTION
prefix_isReady可控制子组件自身的渲染时机,不必在root中书写了
assertNonNullable改为 nonNullable