### PR TITLE
fix: 类型修改

### DIFF
--- a/src/api/InstanceInject/instanceConfig.ts
+++ b/src/api/InstanceInject/instanceConfig.ts
@@ -31,7 +31,7 @@ type injectData = DataConstraint extends IInjectInfo["data"] ? {} : IInjectInfo[
 export type IInjectStore = StoreConstraint extends IInjectInfo["store"] ? {}
   : ReturnTypeInObject<IInjectInfo["store"]>;
 
-export type IInjectMethods = IInjectInfo["methods"];
+export type IInjectMethods = MethodsConstraint extends IInjectInfo["methods"] ? {} : IInjectInfo["methods"];
 
 /**
  * 实例配置接口

--- a/src/api/SlotComponent/index.ts
+++ b/src/api/SlotComponent/index.ts
@@ -13,6 +13,7 @@ import type { RootComponentType } from "../RootComponent/RootComponentType";
 import type { GetStoreDoc } from "../RootComponent/Store/GeTStoreDoc";
 import type { StoreConstraint } from "../RootComponent/Store/StoreConstraint";
 import type { WatchOption } from "../RootComponent/Watch/WatchOption";
+import type { SubComponentType } from "../SubComponent/SubComponentType";
 import type { GetSlotComputedDoc } from "./SlotComputed/GetSlotComputedDoc";
 import type { SlotComputedOption } from "./SlotComputed/SlotComputedOption";
 import type { SlotDataOption } from "./SlotData/SlotDataOption";
@@ -139,11 +140,7 @@ type SlotComponentConstructor<
     AllSuperEvents
   >,
 ) => never;
-type SubComponentType = {
-  allDatas?: Record<string, unknown>;
-  methods?: Record<string, () => unknown>;
-  events?: Record<string, () => unknown>;
-};
+
 export function SlotComponent<
   RootDoc extends RootComponentType,
   SubDoc extends SubComponentType,

--- a/src/api/SubComponent/SubComponentType.ts
+++ b/src/api/SubComponent/SubComponentType.ts
@@ -1,3 +1,4 @@
+import type { Func } from "hry-types/src/Misc/_api";
 import type { CustomEventsTags } from "../RootComponent/CustomEvents/CustomEventsTag";
 
 type _SubComponentType = {
@@ -16,7 +17,8 @@ type _SubComponentType = {
     | CustomEventsTags
   >;
   allDatas?: Record<string, unknown>;
-  methods?: Record<string, unknown>;
+  methods?: Record<string, Func>;
+  events?: Record<string, Func>;
 };
 
 // type _Validator<O, ErrKeys = Exclude<keyof O, SelectKeys<O, Composed, "contains->">>> = [ErrKeys] extends [never]

--- a/src/api/SubComponent/SubEvents/test/normal.test.ts
+++ b/src/api/SubComponent/SubEvents/test/normal.test.ts
@@ -61,6 +61,15 @@ type Sub1Expected = {
     CapturePhaseComposed: string | CaptureComposed;
     BubblesCapturePhaseComposed: string | BubblesCaptureComposed;
   };
+  events: {
+    aaa_str(e: Detail<string>): void;
+    aaa_bubbles(e: Detail<string>): void;
+    aaa_CapturePhase(e: Detail<string>): void;
+    aaa_BubblesCapturePhase(e: Detail<null>): void;
+    aaa_BubblesComposed(e: Detail<string>): void;
+    aaa_CapturePhaseComposed(e: Detail<string>): void;
+    aaa_BubblesCapturePhaseComposed(e: Detail<string>): void;
+  };
 };
 
 // 1.2 Composed事件会被返回
@@ -83,6 +92,10 @@ Checking<typeof sub2, {
   composedEvents: {
     BubblesCapturePhaseComposed: string | BubblesCaptureComposed;
   };
+  events: {
+    aaa_BubblesComposed_catch(e: Detail<string>): void;
+    aaa_CapturePhaseComposed_catch(e: Detail<string>): void;
+  };
 }, Test.Pass>;
 
 const sub3 = SubComponent<{}, CompDoc>()({
@@ -100,7 +113,13 @@ const sub3 = SubComponent<{}, CompDoc>()({
 });
 
 // 2.4 若Composed事件都被阻止则返回never
-Checking<typeof sub3, never, Test.Pass>;
+Checking<typeof sub3, {
+  events: {
+    aaa_BubblesComposed_catch(e: Detail<string>): void;
+    aaa_CapturePhaseComposed_catch(e: Detail<string>): void;
+    aaa_BubblesCapturePhaseComposed_catch(e: Detail<string>): void;
+  };
+}, Test.Pass>;
 
 // 3.1 基础组件基本事件参数为WMBaseEvent
 SubComponent<{}, Wm.View>()({

--- a/src/api/SubComponent/SubReturnType/CreateSubComponentDoc.ts
+++ b/src/api/SubComponent/SubReturnType/CreateSubComponentDoc.ts
@@ -37,10 +37,11 @@ export type CreateSubComponentDoc<
     & IfExtends<EmptyObject, ComposedEvents, {}, { composedEvents: ComposedEvents }>
     & IfExtends<EmptyObject, SubMethods, {}, { methods: SubMethods }>
     & IfExtends<EmptyObject, allDatas, {}, { allDatas: allDatas }>
+    & IfExtends<EmptyObject, SubEventsDoc, {}, { events: SubEventsDoc }>
   >,
 > = IfExtends<
   MissingRequiredField,
   never,
-  IfExtends<EmptyObject, SubCompDoc, never, SubCompDoc>,
+  IfExtends<EmptyObject, SubCompDoc, {}, SubCompDoc>,
   `缺少必传的字段${UnionToComma<MissingRequiredField & string>}`
 >;

--- a/src/api/SubComponent/SubReturnType/test/normal.test.ts
+++ b/src/api/SubComponent/SubReturnType/test/normal.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import { Checking, type Test } from "hry-types";
 import type { ComponentType } from "../../../DefineComponent/ReturnType/ComponentType";
 import type {
@@ -48,14 +49,11 @@ const removeCatchedEvents = SubComponent<{}, CompDoc>()({
     aaa_str: "string",
   },
   events: {
-    aaa_bubblesCaptrueComposed_catch(e) {
-      console.log(e);
+    aaa_bubblesCaptrueComposed_catch() {
     },
-    aaa_bubblesComposed_catch(e) {
-      console.log(e);
+    aaa_bubblesComposed_catch() {
     },
-    aaa_captrueComposed_catch(e) {
-      console.log(e);
+    aaa_captrueComposed_catch() {
     },
   },
 });
@@ -64,6 +62,11 @@ void removeCatchedEvents;
 type RemoveSubDoc = {
   allDatas: {
     aaa_str: "string";
+  };
+  events: {
+    aaa_bubblesCaptrueComposed_catch(): void;
+    aaa_bubblesComposed_catch(): void;
+    aaa_captrueComposed_catch(): void;
   };
 };
 
@@ -74,15 +77,9 @@ const removeCatchedEventsOfSuffix = SubComponent<{}, CompDoc, "aa">()({
     aaaAa_str: "string",
   },
   events: {
-    aaaAa_bubblesCaptrueComposed_catch(e) {
-      console.log(e);
-    },
-    aaaAa_bubblesComposed_catch(e) {
-      console.log(e);
-    },
-    aaaAa_captrueComposed_catch(e) {
-      console.log(e);
-    },
+    aaaAa_bubblesCaptrueComposed_catch() {},
+    aaaAa_bubblesComposed_catch() {},
+    aaaAa_captrueComposed_catch() {},
   },
 });
 void removeCatchedEventsOfSuffix;
@@ -90,6 +87,11 @@ void removeCatchedEventsOfSuffix;
 type RemoveCatchedEventsOfSuffix = {
   allDatas: {
     aaaAa_str: "string";
+  };
+  events: {
+    aaaAa_bubblesCaptrueComposed_catch(): void;
+    aaaAa_bubblesComposed_catch(): void;
+    aaaAa_captrueComposed_catch(): void;
   };
 };
 

--- a/src/api/SubComponent/index.ts
+++ b/src/api/SubComponent/index.ts
@@ -283,13 +283,15 @@ type SubComponentConstructor<
     SubEventsDoc,
     SubMethodsDoc
   >,
-) => CreateSubComponentDoc<
+) => // SubComponentType<
+CreateSubComponentDoc<
   NonNullable<CurrentCompDoc["customEvents"]>,
   SubEventsDoc,
   MissingRequiredField,
   ComputeObject<SubDataDoc & SubComputedDoc & SubStoreDoc>, // allDatas
   SubMethodsDoc
->;
+> // >
+; // must satisfied SubComponentType
 
 /**
  * 子组件构建函数


### PR DESCRIPTION
SubComponentType 加入events字段
IInjectMethods 不会返回约束类型而是{}
CreateSubComponentDoc 不会返回never改为{}

release-as: 1.11.0-alpha.3