### PR TITLE
feat: 注入配置完善组件覆盖逻辑

### DIFF
--- a/jest/inject/duplicate/duplicate.test.ts
+++ b/jest/inject/duplicate/duplicate.test.ts
@@ -24,6 +24,18 @@ instanceConfig.setInjectInfo({
   },
   data: {
     injectStr: "string",
+    injectNum: 123,
+  },
+  methods: {
+    injectMethodA(data: string) {
+      return data;
+    },
+    injectMethodB(data: number) {
+      return data;
+    },
+  },
+  store: {
+    injectTheme: () => "dark",
   },
   behaviors: [behavior],
 });
@@ -45,7 +57,24 @@ describe("inject数据被组件数据覆盖", () => {
     });
 
     expect(checkData.data.injectStr).toBe("changed");
+    expect(checkData.data.injectNum).toBe(123);
 
     expect(checkData.behaviors).toStrictEqual([BthrottleDebounce, behavior, BBeforeCreate]);
+  });
+
+  test("注入store被组件store覆盖", () => {
+    // 组件自身的store覆盖注入的store（注入返回"dark"，组件覆盖为"light"）
+    expect(comp.data.injectTheme).toBe("light");
+  });
+
+  test("注入methods被组件methods覆盖，未覆盖的注入methods仍可用", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = comp.instance as any;
+    // 组件自身的methods覆盖注入的methods
+    expect(instance.injectMethodA("test")).toBe("overridden_by_component");
+    // 未覆盖的注入method仍可用
+    expect(instance.injectMethodB(42)).toBe(42);
+    // 未覆盖的注入data仍可用
+    expect(comp.data.injectNum).toBe(123);
   });
 });

--- a/jest/inject/duplicate/duplicate.ts
+++ b/jest/inject/duplicate/duplicate.ts
@@ -1,5 +1,10 @@
+import { observable } from "mobx";
 import { DefineComponent, RootComponent } from "../../../src";
 import { checkData } from "./duplicate.test";
+
+const customTheme = observable({
+  theme: "light",
+});
 
 const rootComponent = RootComponent()({
   options: {
@@ -10,6 +15,16 @@ const rootComponent = RootComponent()({
   },
   data: {
     injectStr: "changed",
+  },
+  store: {
+    // 组件自身store覆盖注入store
+    injectTheme: () => customTheme.theme,
+  },
+  methods: {
+    // 组件自身方法覆盖注入方法
+    injectMethodA() {
+      return "overridden_by_component" as const;
+    },
   },
   lifetimes: {
     beforeCreate(opt) {

--- a/jest/inject/normal/normal.test.ts
+++ b/jest/inject/normal/normal.test.ts
@@ -26,6 +26,7 @@ instanceConfig.setInjectInfo({
   options,
   data: {
     injectStr: "string",
+    injectNum: 123,
   },
   store: {
     injectTheme: () => store.themeMode,

--- a/src/api/DefineComponent/normalizeOptions/injectInfoHandler.ts
+++ b/src/api/DefineComponent/normalizeOptions/injectInfoHandler.ts
@@ -29,7 +29,7 @@ function mergeOptions(
 
         default:
           // @ts-ignore
-          finalOptionsForComponent[renamedKey] = Object.assign(originalVal, injectVal);
+          finalOptionsForComponent[renamedKey] = Object.assign(injectVal, originalVal);
 
           break;
       }

--- a/src/api/InstanceInject/inject.ts
+++ b/src/api/InstanceInject/inject.ts
@@ -11,15 +11,20 @@ wx.onThemeChange((Res) => {
 });
 
 // 注入的方法;
-function injectMethod(data: string) {
+function injectMethodA(data: string) {
+  return data;
+}
+function injectMethodB(data: number) {
   return data;
 }
 
 const data = {
   injectStr: "injectStr",
+  injectNum: 123,
 };
 const methods = {
-  injectMethod,
+  injectMethodA,
+  injectMethodB,
 };
 const store = {
   injectTheme: () => themeStore.theme,

--- a/src/api/InstanceInject/instanceConfig.ts
+++ b/src/api/InstanceInject/instanceConfig.ts
@@ -19,15 +19,14 @@ interface BaseInjectInfo {
 
 export interface IInjectInfo extends BaseInjectInfo {
 }
+export type InjectData = DataConstraint extends IInjectInfo["data"] ? {} : IInjectInfo["data"];
 
 export type IInjectAllData = IfEquals<
   {},
-  injectData & IInjectStore,
+  InjectData & IInjectStore,
   {},
-  ComputeIntersection<injectData & IInjectStore>
+  ComputeIntersection<InjectData & IInjectStore>
 >;
-
-type injectData = DataConstraint extends IInjectInfo["data"] ? {} : IInjectInfo["data"];
 
 export type IInjectStore = StoreConstraint extends IInjectInfo["store"] ? {}
   : ReturnTypeInObject<IInjectInfo["store"]>;

--- a/src/api/InstanceInject/test/normal.test.ts
+++ b/src/api/InstanceInject/test/normal.test.ts
@@ -10,7 +10,7 @@ RootComponent()({
 
       Checking<typeof this.data.injectTheme, "dark" | "light" | undefined, Test.Pass>;
 
-      Checking<typeof this.injectMethod, (data: string) => string, Test.Pass>;
+      Checking<typeof this.injectMethodA, (data: string) => string, Test.Pass>;
     },
   },
 });
@@ -18,12 +18,12 @@ RootComponent()({
 // 2. 注入字段重复时,自身覆盖注入类型
 RootComponent()({
   data: {
-    // 覆盖注入的数据类型
+    // 覆盖注入的数据类型,注入的类型为string。
     injectStr: 123,
   },
   store: {
-    // 覆盖注入的数据类型
-    injectTheme: (() => "aaa") as () => "aaa",
+    // 覆盖注入的数据类型,注入的类型为"dark" | "light" | undefined。
+    injectTheme: () => "aaa",
   },
   methods: {
     // 覆盖注入的方法类型
@@ -31,9 +31,10 @@ RootComponent()({
       return 123;
     },
     testInjectTypes() {
+      // 覆盖注入的数据类型,注入的类型为string。
       Checking<typeof this.data.injectStr, number, Test.Pass>;
-
-      Checking<typeof this.data.injectTheme, "aaa", Test.Pass>;
+      // 覆盖注入的数据类型,注入的类型为"dark" | "light" | undefined。
+      Checking<typeof this.data.injectTheme, string, Test.Pass>;
 
       Checking<typeof this.injectMethod, () => 123, Test.Pass>;
     },

--- a/src/api/RootComponent/Instance/test/datas/mormal.test.ts
+++ b/src/api/RootComponent/Instance/test/datas/mormal.test.ts
@@ -1,0 +1,43 @@
+import { Checking, type Test } from "hry-types";
+import { type DetailedType, RootComponent } from "../../../../..";
+
+// 组件时
+RootComponent()({
+  properties: {
+    obj: Object,
+    optionalObj: {
+      type: Object as DetailedType<{ name: string }>,
+      value: { name: "zhao" },
+    },
+  },
+  data: {
+    dataStr: "dataStr",
+    // 相同字段覆盖注入类型
+    injectStr: 123,
+  },
+  store: {
+    storeData: (data) => {
+      return data.optionalObj.name;
+    },
+  },
+  lifetimes: {
+    attached() {
+      // 组件实例对象格外添加null类型
+      Checking<
+        typeof this.data,
+        {
+          optionalObj: {
+            name: string;
+          };
+          obj: object;
+          dataStr: string;
+          storeData: string;
+          injectTheme: "dark" | "light" | undefined;
+          injectStr: number; // 相同字段覆盖注入类型 injectStr: string -> number
+          injectNum: number;
+        },
+        Test.Pass
+      >();
+    },
+  },
+});

--- a/src/api/RootComponent/Instance/test/methods/mormal.test.ts
+++ b/src/api/RootComponent/Instance/test/methods/mormal.test.ts
@@ -3,14 +3,23 @@ import { RootComponent } from "../../../../..";
 
 RootComponent()({
   methods: {
+    // 与注入方法同名,会覆盖注入方法
+    injectMethodB(num: string) {
+      return num;
+    },
+
     M1() {
       return 1;
     },
 
     M2(str: string) {
-      void Checking<typeof this.M1, () => 1, Test.Pass>;
+      Checking<typeof this.M1, () => 1, Test.Pass>();
 
-      void Checking<typeof this.M2, (str: string) => string, Test.Pass>;
+      Checking<typeof this.M2, (str: string) => string, Test.Pass>();
+
+      Checking<typeof this.injectMethodA, (str: string) => string, Test.Pass>();
+      // 自身方法会覆盖注入方法,所以类型为自身方法的类型
+      Checking<typeof this.injectMethodB, (num: string) => string, Test.Pass>();
 
       return str;
     },

--- a/src/api/RootComponent/Store/test/normal.test.ts
+++ b/src/api/RootComponent/Store/test/normal.test.ts
@@ -1,3 +1,4 @@
+import { Checking, type Test } from "hry-types";
 import { observable } from "mobx";
 import { typeEqual } from "../../../../utils/_utils";
 import { RootComponent } from "../..";
@@ -9,15 +10,30 @@ const user = observable({
 const storeDoc = RootComponent()({
   properties: {
     condition: Number,
+    optional: {
+      type: Number,
+      value: 10,
+    },
+  },
+  data: {
+    injectStr: 123,
   },
   store: {
-    // normal
+    // 1. 简单的箭头函数写法
     userName: () => user.name,
-    // 条件反应式,当condition>10时,响应式,否则不可响应式(返回undefined),但不报错(有警告).
-    userAge: (props) => {
-      if (props.condition > 10) {
+    // 2. 使用参数 datas
+    userAge: (datas) => {
+      // 参数类型为Required<PropertiesDef> & DataDef & Omit<InjectData, keyof (PropertiesDef & DataDef).
+      Checking<
+        typeof datas,
+        { condition: number; optional: number; injectStr: number; injectNum: number },
+        Test.Pass
+      >();
+
+      if (datas.condition > 10) {
         return user.age;
       }
+      // 返回undefined时字段不会被响应式追踪,不会报错(有警告).
       return undefined;
     },
   },
@@ -25,7 +41,11 @@ const storeDoc = RootComponent()({
 
 type StoreDocExpected = {
   properties: {
+    optional?: number;
     condition: number;
+  };
+  data: {
+    injectStr: number;
   };
   store: {
     userName: string;

--- a/src/api/RootComponent/index.ts
+++ b/src/api/RootComponent/index.ts
@@ -6,7 +6,7 @@ import type { ComputeObject } from "../../types/ComputeObject";
 import type { WMCompOtherOption } from "../../types/OfficialTypeAlias";
 import type { RemoveNullOfRequired } from "../../types/RemoveNullOfRequired";
 import type { ComponentDoc } from "../DefineComponent/returnType/ComponentDoc";
-import type { IInjectStore } from "../InstanceInject/instanceConfig";
+import type { IInjectAllData, IInjectMethods, IInjectStore, InjectData } from "../InstanceInject/instanceConfig";
 import type { ComputedConstraint } from "./Computed/ComputedConstraint";
 import type { ComputedOption } from "./Computed/ComputedOption";
 import type { GetComputedDef } from "./Computed/GetComputedDef";
@@ -46,6 +46,8 @@ type RootComponentOptions<
   DataDef extends object,
   StoreDef extends object,
   ComputedDef extends object,
+  SelfAllDatas extends object,
+  ValidInjectDatas extends object,
 > =
   & MethodsOption<TMethods, keyof (EventsDef & CustomEventsDef)>
   & PropertiesOption<TProperties>
@@ -57,7 +59,7 @@ type RootComponentOptions<
   & ComputedOption<
     TComputed,
     keyof (PropertiesDef & DataDef & StoreDef)
-  > // { data: ComputeObject<DataDef & Required<PropertiesDef> & StoreDef & ComputedDef & IInjectAllData> }
+  >
   & PageLifetimesOption<TIsPage, PropertiesDef>
   & LifetimesOption
   & WatchOption<
@@ -78,9 +80,9 @@ type RootComponentOptions<
   & ThisType<
     RootComponentInstance<
       TIsPage,
-      TMethods,
+      TMethods & Omit<IInjectMethods, keyof TMethods>,
       DataDef,
-      DataDef & Required<PropertiesDef> & StoreDef & ComputedDef,
+      SelfAllDatas & ValidInjectDatas,
       CustomEventsDef,
       StoreDef
     >
@@ -88,7 +90,9 @@ type RootComponentOptions<
 
 type RootComponentConstructor<TComponentDocList extends ComponentDoc[]> = <
   TEvents extends EventsConstraint<TComponentDocList>,
-  TStore extends StoreConstraint<PropertiesDef>,
+  TStore extends StoreConstraint<
+    ComputeIntersection<Required<PropertiesDef> & DataDef & Omit<InjectData, keyof (PropertiesDef & DataDef)>>
+  >,
   TIsPage extends boolean = false,
   const TProperties extends PropertiesConstraint = {},
   TData extends object = {},
@@ -100,8 +104,13 @@ type RootComponentConstructor<TComponentDocList extends ComponentDoc[]> = <
   CustomEventsDef extends object = GetCustomEventsDef<TCustomEvents>,
   PropertiesDef extends object = GetPropertiesDef<TProperties>,
   DataDef extends object = TData,
-  StoreDef extends object = StoreConstraint<PropertiesDef> extends TStore ? {} : GetStoreDef<TStore>,
+  StoreDef extends object = StoreConstraint<
+    ComputeIntersection<Required<PropertiesDef> & DataDef & Omit<InjectData, keyof (PropertiesDef & DataDef)>>
+  > extends TStore ? {}
+    : GetStoreDef<TStore>,
   ComputedDef extends object = GetComputedDef<TComputed>,
+  SelfAllDatas extends object = Required<PropertiesDef> & DataDef & StoreDef & ComputedDef,
+  ValidInjectDatas extends object = Omit<IInjectAllData, keyof SelfAllDatas>,
 >(
   options: RootComponentOptions<
     TEvents,
@@ -118,7 +127,9 @@ type RootComponentConstructor<TComponentDocList extends ComponentDoc[]> = <
     PropertiesDef,
     DataDef,
     StoreDef,
-    ComputedDef
+    ComputedDef,
+    SelfAllDatas,
+    ValidInjectDatas
   >,
 ) => // 生成RootComponentDefinition
 ComputeIntersection<
@@ -149,3 +160,5 @@ export function RootComponent<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (options: any) => options;
 }
+
+// 全局实例增加 有效的注入数据,store字段参数包含 (prop + data + 有效的注入数据)


### PR DESCRIPTION
- 全局实例增加有效的注入数据(ValidInjectDatas),剔除组件自身已定义字段
- store字段参数扩展为 prop + data + 有效的注入数据
- methods字段支持组件覆盖注入:组件方法优先,未覆盖的注入方法保留
- ThisType中this.data包含自身数据+有效注入数据
- watch/observers参数新增注入store类型支持